### PR TITLE
Multiple fixes to get the tool working in 2022

### DIFF
--- a/UCI_ML_Functions.py
+++ b/UCI_ML_Functions.py
@@ -473,9 +473,9 @@ def download_file(url, directory):
     Downloads a file from a given url into the given directory.
     """
     import requests
-    import os
+    from pathlib import Path
 
-    local_filename = directory + "/" + url.split("/")[-1]
+    local_filename = Path(directory) /  Path(url.split("/")[-1])
     # NOTE the stream=True parameter
     r = requests.get(url, stream=True)
     try:
@@ -502,13 +502,14 @@ def download_dataset_url(url, directory, msg_flag=False, download_flag=True):
     from bs4 import BeautifulSoup
     import ssl
     import os
+    from pathlib import Path
 
     if url == "URL not available":
         return None
 
     cwd = os.getcwd()
     directory = directory.replace(":", "-")
-    local_directory = cwd + "\\" + str(directory)
+    local_directory = Path(cwd) / Path(str(directory))
     if not os.path.exists(local_directory):
         try:
             os.makedirs(local_directory)

--- a/UCI_ML_Functions.py
+++ b/UCI_ML_Functions.py
@@ -7,7 +7,7 @@ def read_dataset_table(
     url="https://archive.ics.uci.edu/ml/datasets.php", msg_flag=True
 ):
     """
-    Reads the table of datasets from the url: "https://archive.ics.uci.edu/ml/datasets.html" and process it further to clean and categorize
+    Reads the table of datasets from the url: "https://archive.ics.uci.edu/ml/datasets.php" and process it further to clean and categorize
     """
     import pandas as pd
 
@@ -206,7 +206,7 @@ def build_dataset_list(url="https://archive.ics.uci.edu/ml/datasets", msg_flag=T
 # Function to create dictionary of datasets' name, description, and identifier string
 # ======================================================================================
 def build_dataset_dictionary(
-    url="https://archive.ics.uci.edu/ml/datasets.html?format=&task=&att=&area=&numAtt=&numIns=&type=&sort=nameUp&view=list",
+    url="https://archive.ics.uci.edu/ml/datasets.php?format=&task=&att=&area=&numAtt=&numIns=&type=&sort=nameUp&view=list",
     msg_flag=True,
 ):
     """
@@ -352,7 +352,7 @@ def build_local_database(filename=None, msg_flag=True):
 def return_abstract(name, local_database=None, msg_flag=False):
     """
     Returns one-liner description (and webpage link for further information) of a particular dataset by searching the given name.
-    local_database: Name of the database (CSV file) stored locally i.e. in the same directory, which contains information about all the datasets on UCI ML repo. 
+    local_database: Name of the database (CSV file) stored locally i.e. in the same directory, which contains information about all the datasets on UCI ML repo.
     msg_flag: Controls verbosity
     """
 
@@ -601,7 +601,7 @@ def download_datasets(num=10, local_database=None, msg_flag=True, download_flag=
 def download_dataset_name(name, local_database=None, msg_flag=True, download_flag=True):
     """
     Downloads a particular dataset by searching the given name.
-    local_database: Name of the database (CSV file) stored locally i.e. in the same directory, which contains information about all the datasets on UCI ML repo. 
+    local_database: Name of the database (CSV file) stored locally i.e. in the same directory, which contains information about all the datasets on UCI ML repo.
     msg_flag: Controls verbosity
     download_flag: Default is True. If set to False, only creates the directories but does not initiate download (for testing purpose)
     """
@@ -683,7 +683,7 @@ def download_datasets_size(
     Downloads all datasets which satisfy the 'size' criteria.
     size: Size of the dataset which user wants to download. Could be any of the following: 'Small', 'Medium', 'Large','Extra Large'.
     local_database: Name of the database (CSV file) stored locally i.e. in the same directory, which contains name and URL information about all the datasets on UCI ML repo.
-    local_table: Name of the database (CSV file) stored locally i.e. in the same directory, which contains features information about all the datasets on UCI ML repo i.e. number of samples, type of machine learning task to be performed with the dataset. 
+    local_table: Name of the database (CSV file) stored locally i.e. in the same directory, which contains features information about all the datasets on UCI ML repo i.e. number of samples, type of machine learning task to be performed with the dataset.
     msg_flag: Controls verbosity
     download_flag: Default is True. If set to False, only creates the directories but does not initiate download (for testing purpose)
     """
@@ -736,15 +736,15 @@ def download_datasets_task(
 ):
     """
     Downloads all datasets which satisfy the size criteria.
-    task: Machine learning task for which user wants to download the datasets. Could be any of the following: 
-	    'Classification', 
-		'Recommender Systems', 
-		'Regression', 
-		'Other/Unknown', 
-		'Clustering', 
+    task: Machine learning task for which user wants to download the datasets. Could be any of the following:
+	    'Classification',
+		'Recommender Systems',
+		'Regression',
+		'Other/Unknown',
+		'Clustering',
 		'Causal Discovery'.
 	local_database: Name of the database (CSV file) stored locally i.e. in the same directory, which contains name and URL information about all the datasets on UCI ML repo.
-	local_table: Name of the database (CSV file) stored locally i.e. in the same directory, which contains features information about all the datasets on UCI ML repo i.e. number of samples, type of machine learning task to be performed with the dataset. 
+	local_table: Name of the database (CSV file) stored locally i.e. in the same directory, which contains features information about all the datasets on UCI ML repo i.e. number of samples, type of machine learning task to be performed with the dataset.
 	msg_flag: Controls verbosity
     download_flag: Default is True. If set to False, only creates the directories but does not initiate download (for testing purpose).
     """

--- a/UCI_ML_Functions.py
+++ b/UCI_ML_Functions.py
@@ -21,14 +21,6 @@ def read_dataset_table(
         print("Could not read the table from UCI ML portal, Sorry!")
 
     df = datasets[5]  # Fifth entry of this table is the main datasets information
-    # Rows and columns of the dataframe
-    nrows = df.shape[0]
-    ncols = df.shape[1]
-
-    # Read the pertinent rows (skipping every alternate one) and columns
-    df = df.iloc[1:nrows:2][[2, 3, 4, 5, 6, 7, 8]]
-
-    # Assign column names
     df.columns = [
         "Name",
         "Data Types",
@@ -38,9 +30,8 @@ def read_dataset_table(
         "Number of Attributes",
         "Year",
     ]
-
-    # Set index from 1
-    df.index = [i for i in range(1, int(nrows / 2) + 1)]
+    # Remove first row which contains table header
+    df = df.iloc[1:, :]
 
     return df
 


### PR DESCRIPTION
In the process of getting the tool working I needed to make several changes.

- Change '.html' to '.php' in path to UCI repository. The URL was probably updated in the past years and got out of sync
- Function read_dataset_table was skipping every other row and the first two columns in the parsed table from HTML. This was no longer valid for the current format of the table
- Path concatenation was not multiplatform and download of dataset was crashing on MacOS